### PR TITLE
Customize "Found a problem" link to include current URL

### DIFF
--- a/views/01WRLC_GWA-live/html/homepage/homepage_en.html
+++ b/views/01WRLC_GWA-live/html/homepage/homepage_en.html
@@ -35,7 +35,7 @@
                    <li><a href="https://library.gwu.edu/help/reference/ask-us" target="_blank">Ask Us</a></li>
                    <li>Visit the <a href="https://library.gwu.edu/howdoi" target="_blank">How Do I</a> page for search tips and helpful videos.</li>
                 </ul>
-                <p><a href="https://goo.gl/forms/B9PRKfPiIlsrasrx2" target="_blank">Found a problem?</p>
+                <p><a href="https://library.gwu.edu/found-problem" target="_blank">Found a problem?</p>
             </md-card-content>
         </md-card>
     </div>

--- a/views/01WRLC_GWA-live/js/custom.js
+++ b/views/01WRLC_GWA-live/js/custom.js
@@ -31,9 +31,17 @@
      */
 
     /* Insert found a problem link */
-    app.component('prmFullViewServiceContainerAfter', {
-        template: '<a class="layout-align-left-left layout-column" id="found-problem" href="https://library.gwu.edu/found-problem" target="_blank">Found a Problem?</a>'
+    app.controller('foundProblem', function () {
+        var vm = this;
+        var currentURL = encodeURIComponent(window.location.href);
+        var foundProblemForm = 'https://library.gwu.edu/found-problem'
+        var vm.foundProblemCombinedURL = foundProblemForm + '?url=' + currentURL;
     });
+    app.component('prmFullViewServiceContainerAfter', {
+        contoller: 'foundProblem',
+        template: '<a class="layout-align-left-left layout-column" id="found-problem" href="{{ $ctrl.foundProblemCombinedURL }}" target="_blank">Found a Problem?</a>'
+    });
+
     /*
       // Uncomment for test profile customization package    
       // Add link to fines and fees payment 

--- a/views/01WRLC_GWA-live/js/custom.js
+++ b/views/01WRLC_GWA-live/js/custom.js
@@ -38,7 +38,7 @@
         var vm.foundProblemCombinedURL = foundProblemForm + '?url=' + currentURL;
     });
     app.component('prmFullViewServiceContainerAfter', {
-        contoller: 'foundProblem',
+        controller: 'foundProblem',
         template: '<a class="layout-align-left-left layout-column" id="found-problem" href="{{ $ctrl.foundProblemCombinedURL }}" target="_blank">Found a Problem?</a>'
     });
 


### PR DESCRIPTION
I was noticing that the Primo listserv had some recent discussions about including one's current URL in "Found a problem?" links, and Emery Shriver at Williams linked to [an article he wrote about it](https://journal.code4lib.org/articles/14481), which also linked to a [code example](https://github.com/emery-williams/reportproblem/blob/master/reportproblem.js) of how he did it.

I tried to combine something what he did with what was currently in place for that link while also looking over Ian's slides from the presentation about customizing Primo, but I'm not sure I got things right (I also made the changes blindly, so not tested on a local view or anything, in case that explains potential syntax issues or whatever). Feel free to adjust.

The first commit was also just because I happened to notice that the "homepage" had the old link to the Google Form, which Joscelyn confirmed to me was supposed to be replaced by the webform on libsite. We also discussed the fact that some of the existing submissions have non-Primo URLs in the "URL of the page where you encountered the problem" field, but she thought it's still sometimes useful to know _how_ people got to a different resource. Of course, maybe y'all will have different opinions and thus maybe want to reject this pull request.

I'll also note that getting the `url` parameter to pre-fill on the libsite Drupal webform does require changing that webform's default value for that field to `[current-page:query:url]` (which I tested out on libsite's test server).